### PR TITLE
kphp-inspector: add strict search

### DIFF
--- a/kphp-inspector/index.js
+++ b/kphp-inspector/index.js
@@ -56,6 +56,9 @@ function parseConsoleArgv(argv) {
       case '--version':
         env.RUN_ARGV.JUST_SHOW_VERSION = true;
         break;
+      case '--debug':
+        env.RUN_ARGV.DEBUG = true;
+        break;
     }
   }
 }

--- a/kphp-inspector/src/env.js
+++ b/kphp-inspector/src/env.js
@@ -14,6 +14,8 @@ const RUN_ARGV = {
   JUST_INFO_ABOUT_CLASS: '',
   JUST_SHOW_HELP: false,
   JUST_SHOW_VERSION: false,
+
+  DEBUG: false,
 };
 
 module.exports.VERSION = VERSION;

--- a/kphp-inspector/src/file_searcher.js
+++ b/kphp-inspector/src/file_searcher.js
@@ -154,9 +154,9 @@ function findFunctionFilesWithNameLike(name, searchPrefix = false) {
 }
 
 /**
- * Function searches for files in `searchFolder` that have the `query` substring in the name.
+ * Function searches for files in `searchFolder` that have the `name` substring in the name.
  *
- * If `searchPrefix` is true, then the search will search for files with the `query` prefix.
+ * If `searchPrefix` is true, then the search will search for files with the `name` prefix.
  *
  * @param {string} name          Filename to search
  * @param {string} searchFolder  Folder among the files to be searched

--- a/kphp-inspector/src/file_searcher.js
+++ b/kphp-inspector/src/file_searcher.js
@@ -103,15 +103,20 @@ function performSearchForClass(query) {
  * @returns {[string[], string]}
  */
 function queryToParts(query) {
-  let queryParts = splitUserSearchStr(query);
+  let queryParts = query
+    .toLowerCase()
+    .trim()
+    .split(/[\\,+\s:()]/)
+    .map(p => p.trim())
+    .filter(p => p !== '');
   if (queryParts.length === 0) {
     return [[], ''];
   }
 
   utils.debug(`Query parts: ${queryParts.join(', ')}`);
 
-  let longestQueryLen = Math.max(...queryParts.map(p => p.length));
-  let longestPart = queryParts.find(p => p.length === longestQueryLen);
+  let longestPartLen = Math.max(...queryParts.map(p => p.length));
+  let longestPart = queryParts.find(p => p.length === longestPartLen);
 
   return [queryParts, longestPart];
 }
@@ -158,7 +163,7 @@ function findFunctionFilesWithNameLike(name, searchPrefix = false) {
  * @param {boolean} searchPrefix Specifies whether to search for a prefix or a substring
  * @return {string[]}            An array of found files
  */
-function findFilesWithNameLike(name, searchFolder = env.RUN_ARGV.KPHP_COMPILED_ROOT, searchPrefix = false) {
+function findFilesWithNameLike(name, searchFolder, searchPrefix = false) {
   const findQuery = searchPrefix ? `${name}*` : `*${name}*`;
 
   const command = `find ${searchFolder} -iname "${findQuery}"`;
@@ -194,15 +199,5 @@ function convertFqnToKphpStyleCppFileName(fqn) {
     .replace(/\\/g, '@');
 }
 
-/**
- * Convert search string "ClassName::method" to ['classname','method'], "VK Feed something" to ['vk','feed','something']
- * @param {string} q
- * @return {string[]}
- */
-function splitUserSearchStr(q) {
-  return q.toLowerCase().trim().split(/[\\,+\s:()]/).map(p => p.trim()).filter(p => p !== '');
-}
-
-module.exports.splitUserSearchStr = splitUserSearchStr;
 module.exports.performSearchForFunction = performSearchForFunction;
 module.exports.performSearchForClass = performSearchForClass;

--- a/kphp-inspector/src/file_searcher.js
+++ b/kphp-inspector/src/file_searcher.js
@@ -74,11 +74,11 @@ function performSearchForClass(query) {
   utils.debug(`Start search class by query: ${query}`);
 
   if (isFQN) {
-    const className = convertFqnToKphpStyleCppFileName(query);
-    const classNameWithDot = className + '\\.';
-    utils.debug(`Filename for search: ${classNameWithDot}`);
+    const filename = convertFqnToKphpStyleCppFileName(query);
+    const filenameWithDot = filename + '\\.';
+    utils.debug(`Filename for search: ${filenameWithDot}`);
 
-    const files = findClassFilesWithNameLike(classNameWithDot);
+    const files = findClassFilesWithNameLike(filenameWithDot);
     utils.debug(`Found files: ${files.length === 0 ? 'empty' : files.join(', ')}`);
 
     return files.filter(filename => filename.endsWith('.h'));
@@ -120,23 +120,23 @@ function queryToParts(query) {
  * Searches for files for classes.
  * @see findFilesWithNameLike
  *
- * @param {string} query Search string from console
- * @return {string[]}    An array of found files
+ * @param {string} name Filename to search
+ * @return {string[]}   An array of found files
  */
-function findClassFilesWithNameLike(query) {
-  return findFilesWithNameLike(query, `${env.RUN_ARGV.KPHP_COMPILED_ROOT}/cl`, false);
+function findClassFilesWithNameLike(name) {
+  return findFilesWithNameLike(name, `${env.RUN_ARGV.KPHP_COMPILED_ROOT}/cl`, false);
 }
 
 /**
  * Searches for files for functions with additional filtering.
  * @see findFilesWithNameLike
  *
- * @param {string} query         Search string from console
+ * @param {string} name          Filename to search
  * @param {boolean} searchPrefix Specifies whether to search for a prefix or a substring
  * @return {string[]}            An array of found files
  */
-function findFunctionFilesWithNameLike(query, searchPrefix = false) {
-  return findFilesWithNameLike(query, env.RUN_ARGV.KPHP_COMPILED_ROOT, searchPrefix)
+function findFunctionFilesWithNameLike(name, searchPrefix = false) {
+  return findFilesWithNameLike(name, env.RUN_ARGV.KPHP_COMPILED_ROOT, searchPrefix)
     .filter((filename, _, output) =>
       // strip out duplicates and strange files: leave only .cpp and .h, also filter out .h files of classes
       filename.endsWith('.cpp') ||
@@ -153,18 +153,13 @@ function findFunctionFilesWithNameLike(query, searchPrefix = false) {
  *
  * If `searchPrefix` is true, then the search will search for files with the `query` prefix.
  *
- * @param {string} query         Search string from console
+ * @param {string} name          Filename to search
  * @param {string} searchFolder  Folder among the files to be searched
  * @param {boolean} searchPrefix Specifies whether to search for a prefix or a substring
  * @return {string[]}            An array of found files
  */
-function findFilesWithNameLike(query, searchFolder = env.RUN_ARGV.KPHP_COMPILED_ROOT, searchPrefix = false) {
-  let findQuery;
-  if (searchPrefix) {
-    findQuery = `${query}*`;
-  } else {
-    findQuery = `*${query}*`;
-  }
+function findFilesWithNameLike(name, searchFolder = env.RUN_ARGV.KPHP_COMPILED_ROOT, searchPrefix = false) {
+  const findQuery = searchPrefix ? `${name}*` : `*${name}*`;
 
   const command = `find ${searchFolder} -iname "${findQuery}"`;
 

--- a/kphp-inspector/src/utils.js
+++ b/kphp-inspector/src/utils.js
@@ -1,0 +1,13 @@
+// Compiler for PHP (aka KPHP) tools
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+const env = require('./env');
+
+function debug(value) {
+  if (!env.RUN_ARGV.DEBUG) return;
+
+  console.log(value);
+}
+
+module.exports.debug = debug;


### PR DESCRIPTION
Now, if a class or function begins with a slash, then we treat the name as FQN and run strict search.

Strict search means that we are searching strictly by FQN.

The first thing we do is turn the FQN into the filename that the FQN is supposed to be in.

For example:
```
\VK\Namespace\SomeClass::__construct
// to
VK@Namespace@SomeClass@@__construct
```

After that, we limit this name with a dot on the right, thus we will only search for paths with this name.

```
VK@Namespace@SomeClass@@__construct.
```

And then we just start the file search, as in the current non-strict implementation.

Also added the `--debug` flag, more intended for embedding with the logging system for tools using kphp-inspector.